### PR TITLE
Makefile: improve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+ddcutil-service
+ddcutil-client

--- a/Makefile
+++ b/Makefile
@@ -10,32 +10,41 @@ CFLAGS_DDCUTIL = $(shell pkg-config --cflags --libs ddcutil)
 #CFLAGS_DDCUTIL = -isystem $(HOME)/Downloads/ddcutil-2.0.0/src/public -L $(HOME)/Downloads/ddcutil-2.0.0/src/.libs -lddcutil
 #CFLAGS_DDCUTIL = -isystem $(HOME)/Downloads/ddcutil-2.2.0/src/public -L $(HOME)/Downloads/ddcutil-2.2.0/src/.libs -lddcutil
 
-CFLAGS += -g -std=gnu11 -Werror -Wall -Wformat-security -Og
-SOURCE = ddcutil-service.c
-EXE = ddcutil-service
-
-# The client is an optional deployable
-CLIENT_EXE = ddcutil-client
-CLIENT_SOURCE = ddcutil-client.c
+OPT_LEVEL = -Og
+CFLAGS += -g -std=gnu11 -Werror -Wall -Wformat-security $(OPT_LEVEL)
 
 PREFIX = $(HOME)/.local
 BIN_DIR = $(PREFIX)/bin
 SERVICE_FILE = com.ddcutil.DdcutilService.service
 SERVICES_DIR = $(PREFIX)/share/dbus-1/services
+MAN_DIR = $(PREFIX)/share/man
 
-all: $(SOURCE) $(EXE) $(CLIENT_EXE) $(HTML)
+.PHONY: all
+all: ddcutil-service ddcutil-client
 
-$(EXE): $(SOURCE)
+ddcutil-service: ddcutil-service.c
 	gcc $< -o $@ $(CFLAGS) $(CFLAGS_GIO) $(CFLAGS_DDCUTIL)
 
-$(CLIENT_EXE): $(CLIENT_SOURCE)
+# The client is an optional deployable
+ddcutil-client: ddcutil-client.c
 	gcc $< -o $@ $(CFLAGS) $(CFLAGS_GIO)
 
-install: $(EXE)
-	sed 's?/usr/bin/?$(BIN_DIR)/?' < $(SERVICE_FILE) > $(SERVICE_FILE).tmp
-	mkdir -p $(SERVICES_DIR) $(BIN_DIR)
-	install $(SERVICE_FILE).tmp $(SERVICES_DIR)/$(SERVICE_FILE)
-	install $(EXE) $(BIN_DIR)
+.PHONY: install
+install: ddcutil-service ddcutil-service.1 ddcutil-service.7 com.ddcutil.DdcutilService.service
+	install -Dm644 com.ddcutil.DdcutilService.service -t $(SERVICES_DIR)
+	sed -i 's?/usr/bin/?$(BIN_DIR)/?g' $(SERVICES_DIR)/com.ddcutil.DdcutilService.service
+	install -Dm755 ddcutil-service -t $(BIN_DIR)
+	install -Dm644 ddcutil-service.1 -t $(MAN_DIR)/man1
+	install -Dm644 ddcutil-service.7 -t $(MAN_DIR)/man7
 
+.PHONY: install-client
+install-client: ddcutil-client ddcutil-client.1
+	install -Dm755 ddcutil-client -t $(BIN_DIR)
+	install -Dm644 ddcutil-client.1 -t $(MAN_DIR)/man1
+
+.PHONY: install-all
+install-all: install install-client
+
+.PHONY: clean
 clean:
-	rm -f $(EXE) $(CLIENT_EXE)
+	rm -f ddcutil-client ddcutil-service


### PR DESCRIPTION
- install manpages
- use .PHONY for non file targets
- target to install the client
- target to install both the client and the service
- use the -D -m and -t flags to the install command to make commands more concise
- configurable optimization level
- inline unneeded variables, this makes the makefile look less cluttered